### PR TITLE
docs: fix type

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ for all available options.
 // in gatsby-config.js
 plugins: [
   {
-    resolve: `gatsby-plugin-sass`,
+    resolve: `gatsby-plugin-elm`,
     options: {
       forceWatch: true,
     },


### PR DESCRIPTION
I guess it should read `gatsby-plugin-elm` instead of `gatsby-plugin-sass` 🤷‍♂️